### PR TITLE
Fix for computing mins and max to ignore float NaN value

### DIFF
--- a/src/parseData.js
+++ b/src/parseData.js
@@ -22,7 +22,7 @@ function processResult(result, debug) {
 
         for (let columnIndex = 0; columnIndex < width; columnIndex++) {
           const value = row[columnIndex];
-          if (value != noDataValue) {
+          if (value != noDataValue && !isNaN(value)) {
             if (typeof min === 'undefined' || value < min) min = value;
             else if (typeof max === 'undefined' || value > max) max = value;
           }


### PR DESCRIPTION
 Fix for computing mins and max to ignore float NaN value, as in a GeoTIFF with floats that can indicates a no-data value.

In Java Geotools GeoTiffWriter NaN is used as default no-data value for double and float. But it also does not store that value in the noData metadata field if it is NaN apparently.

The code does not handle float NaN special in comparisons. As a result, when the first value encountered is a NaN, it was always putting mins and maxs to NaN, as comparing a value with NaN always returns false. The fix ignores NaN values, putting mins and maxs to a useful range of values.