### PR TITLE
Directly specify which bundle to use in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "1.2.0",
   "description": "Wrapper around Georeferenced Rasters like GeoTIFF, NetCDF, JPG, and PNG that provides a standard interface",
   "main": "dist/georaster.bundle.min.js",
-  "browser": {
-    "./dist/georaster.bundle.min.js": "./dist/georaster.browser.bundle.min.js"
-  },
+  "browser": "./dist/georaster.browser.bundle.min.js",
   "unpkg": "./dist/georaster.browser.bundle.min.js",
   "scripts": {
     "analyze": "ANALYZE_GEORASTER_BUNDLE=true npm run build",


### PR DESCRIPTION
Similar to https://github.com/GeoTIFF/geoblaze/pull/170, set the browser key differently, should fix issues with loading the library in Angular and other projects.