### PR TITLE
Add Typescript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "test-dev": "npm run dev && GEORASTER_TEST_BUNDLE_NAME='georaster.bundle.js' node ./node_modules/.bin/mocha --reporter spec",
     "test-prod": "npm run build && GEORASTER_TEST_BUNDLE_NAME='georaster.bundle.min.js' node ./node_modules/.bin/mocha --reporter spec",
     "dev": "webpack --mode development --target node && webpack --mode development --target web",
-    "build": "npm run build:prod",
+    "build": "npm run build:prod && npm run build:types",
     "build:prod": "npm run build:prod:node && npm run build:prod:web",
     "build:prod:node": "webpack --mode production --target node",
-    "build:prod:web": "webpack --mode production --target web"
+    "build:prod:web": "webpack --mode production --target web",
+    "build:types": "cp src/georaster.d.ts dist/georaster.d.ts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/georaster.bundle.min.js",
   "browser": "./dist/georaster.browser.bundle.min.js",
   "unpkg": "./dist/georaster.browser.bundle.min.js",
+  "types": "dist/georaster.d.ts",
   "scripts": {
     "analyze": "ANALYZE_GEORASTER_BUNDLE=true npm run build",
     "clean": "rm -f ./dist/*",

--- a/src/georaster.d.ts
+++ b/src/georaster.d.ts
@@ -31,7 +31,6 @@ export interface Georaster {
   ranges: number[]
 }
 
-/** Subset of Georaster properties */
 export type GeorasterMetadata = Pick<Georaster, 'noDataValue' | 'projection' | 'xmin' | 'ymax' | 'pixelWidth' | 'pixelHeight'>
 
 export function parseGeoraster(data: object | string | Buffer | ArrayBuffer | number[][][],

--- a/src/georaster.d.ts
+++ b/src/georaster.d.ts
@@ -1,0 +1,40 @@
+export interface Georaster {
+  /** raster values.  first dimension is raster band, remainder is 2D array of cell values */
+  values: number[][][];
+  /** raster height in units of projection */
+  height: number;
+  /** raster width in units of projection */
+  width: number;
+  /** raster height in pixels */
+  pixelHeight: number;
+  /** raster width in pixels */
+  pixelWidth: number;
+  /** Projection identifier */
+  projection: unknown;
+  /** left boundary, in units of projection*/
+  xmin: number;
+  /** right boundary, in units of projection */
+  xmax: number;
+  /** top boundary (image y-axis is inverse of cartesian), in units of projection */
+  ymin: number;
+  /** bottom boundary (image y-axis is inverse of cartesian), in units of projection */
+  ymax: number;
+  /** cell value representing "no data" in raster */
+  noDataValue: number;
+  /** number of raster bands */
+  numberOfRasters: number;
+  /** Minimum cell value for each raster band.  Indexed by band number */
+  mins: number[]
+  /** Maximum cell value for each raster band.  Indexed by band number */
+  maxs: number[]
+  /** difference between max and min for each raster band.  Indexed by band number */
+  ranges: number[]
+}
+
+/** Subset of Georaster properties */
+export type GeorasterMetadata = Pick<Georaster, 'noDataValue' | 'projection' | 'xmin' | 'ymax' | 'pixelWidth' | 'pixelHeight'>
+
+export function parseGeoraster(data: object | string | Buffer | ArrayBuffer | number[][][],
+    metadata: GeorasterMetadata,
+    debug: boolean
+): Promise<Georaster>


### PR DESCRIPTION
Goal - add Typescript definitions.  cc @DanielJDufour 

Details:
- Covers the public API for the top-level module only including the `parseGeoraster() method and the `Georaster` object it returns.
- Adds a build step to copy to declaration file from src to dist folder.

Matching Geoblaze PR builds on this - https://github.com/GeoTIFF/geoblaze/pull/183