### PR TITLE
load from File/Blob on front-end

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,10 @@ class GeoRaster {
       this._url = data;
       this.rasterType = 'geotiff';
       this.sourceType = 'url';
+    } else if (typeof Blob !== 'undefined' && data instanceof Blob) {
+      this._data = data;
+      this.rasterType = 'geotiff';
+      this.sourceType = 'Blob';
     } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(data)) {
       // this is node
       if (debug) console.log('data is a buffer');

--- a/src/parseData.js
+++ b/src/parseData.js
@@ -1,4 +1,4 @@
-import {fromArrayBuffer, fromUrl} from 'geotiff';
+import {fromArrayBuffer, fromUrl, fromBlob} from 'geotiff';
 import {getPalette} from 'geotiff-palette';
 import {unflatten} from './utils.js';
 
@@ -74,6 +74,8 @@ export default function parseData(data, debug) {
         let initFunction = fromArrayBuffer;
         if (data.sourceType === 'url') {
           initFunction = fromUrl;
+        } else if (data.sourceType === 'Blob') {
+          initFunction = fromBlob;
         }
 
         if (debug) console.log('data.rasterType is geotiff');


### PR DESCRIPTION
Use geotiff package fromBlob() function to read File/Blob object
directly rather than copying data to ArrayBuffer object or using
createObjectURL() to create URL string for File/Blob object.